### PR TITLE
Implement Background Options Menu UI to interchangeably change between different backgrounds

### DIFF
--- a/frontend/src/app/game/GameController.ts
+++ b/frontend/src/app/game/GameController.ts
@@ -91,6 +91,7 @@ export default class GameController {
         this.backgroundInitialPosition.y
       ),
       this.k.scale(this.backgroundScale),
+      this.k.z(0), // Make sure it's rendered behind everything
     ]);
   }
 
@@ -116,6 +117,7 @@ export default class GameController {
       this.k.sprite(targetPlayer.name, { anim: "idle" }),
       this.k.pos(left + previousPosition.x, previousPosition.y),
       this.k.scale(this.playerScale),
+      this.k.z(10), // Ensure it's rendered above background
       {
         speed: this.playerWalkingSpeed, // walking speed by pixels per second
         direction: this.k.vec2(0, 0), // walking direction
@@ -151,6 +153,7 @@ export default class GameController {
       this.k.rect(this.k.width(), this.platformHeight),
       this.k.color(r, g, b),
       this.k.pos(0, this.k.height() - this.platformHeight),
+      this.k.z(10), // Ensure it's rendered above background
     ]);
 
     // Add a black outline/border at the top of the platform
@@ -158,6 +161,7 @@ export default class GameController {
       this.k.rect(this.k.width(), 8),
       this.k.color(0, 0, 0),
       this.k.pos(0, 0),
+      this.k.z(10), // Ensure it's rendered above background
     ]);
   }
 

--- a/frontend/src/app/game/components/AnimatedSpritePreview.tsx
+++ b/frontend/src/app/game/components/AnimatedSpritePreview.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { BaseSprite } from "../gameAssets";
+
+export default function AnimatedSpritePreview<T extends BaseSprite>({
+  sprite,
+  width,
+  height,
+  isStatic = false,
+}: {
+  sprite: T;
+  width: number;
+  height: number;
+  isStatic?: boolean;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const frameRef = useRef(0); // Tracks the current animation frame
+  const intervalRef = useRef<number | null>(null); // Holds the animation interval ID for cleanup
+
+  useEffect(() => {
+    // Get canvas drawing context
+    const ctx = canvasRef.current?.getContext("2d");
+    if (!ctx) return;
+
+    // Disable smoothing to keep pixel art crisp
+    ctx.imageSmoothingEnabled = false;
+
+    // Load the sprite sheet image
+    const image = new Image();
+    image.src = sprite.path;
+
+    /**
+     * Draws the current frame of the sprite animation to canvas
+     * Uses sprite slicing to extract individual frames from a sprite sheet
+     */
+    const draw = () => {
+      if (!canvasRef.current || !image.complete) return;
+
+      // Get the frame ID from the sprite's idle animation sequence
+      const frameId = sprite.anims.idle.frames[frameRef.current];
+
+      // Calculate the position of this frame on the sprite sheet
+      const frameX = frameId % sprite.sliceX;
+      const frameY = Math.floor(frameId / sprite.sliceX);
+
+      // Calculate the width and height of each frame on the sprite sheet
+      const frameWidth = image.width / sprite.sliceX;
+      const frameHeight = image.height / sprite.sliceY;
+
+      // Clear the canvas before drawing new frame
+      ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+
+      // Draw the specific frame from the sprite sheet to the canvas
+      ctx.drawImage(
+        image,
+        frameX * frameWidth,
+        frameY * frameHeight,
+        frameWidth,
+        frameHeight,
+        0,
+        0,
+        canvasRef.current.width,
+        canvasRef.current.height
+      );
+    };
+
+    // When image loads, set up animation loop
+    image.onload = () => {
+      frameRef.current = 0;
+      draw();
+
+      // Skip animation setup if static
+      if (isStatic) return;
+
+      // Clear any existing animation interval
+      if (intervalRef.current) clearInterval(intervalRef.current);
+
+      // Set up animation loop
+      intervalRef.current = window.setInterval(() => {
+        frameRef.current =
+          (frameRef.current + 1) % sprite.anims.idle.frames.length;
+        draw();
+      }, 1000 / sprite.anims.idle.speed); // Convert speed to milliseconds
+    };
+
+    // Clear canvas on initial render
+    ctx.clearRect(0, 0, width, height);
+
+    // Cleanup function
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [canvasRef, sprite, width, height, isStatic]);
+
+  return (
+    <canvas ref={canvasRef} id="sprite-preview" width={width} height={height} />
+  );
+}

--- a/frontend/src/app/game/components/SpritePreviewOption.tsx
+++ b/frontend/src/app/game/components/SpritePreviewOption.tsx
@@ -1,0 +1,52 @@
+import { BaseSprite } from "../gameAssets";
+import AnimatedSpritePreview from "./AnimatedSpritePreview";
+
+export default function SpritePreviewOption<T extends BaseSprite>({
+  name,
+  sprite,
+  selectedSprite,
+  setSelectedSprite,
+  width,
+  height,
+}: {
+  name: string;
+  sprite: T;
+  selectedSprite: T;
+  setSelectedSprite: (s: T) => void;
+  width: number;
+  height: number;
+}) {
+  const selected = sprite.name === selectedSprite.name;
+  return (
+    <label
+      key={sprite.displayName}
+      htmlFor={sprite.displayName}
+      className="flex flex-col justify-center items-center p-2"
+    >
+      <input
+        type="radio"
+        id={sprite.displayName}
+        name={name}
+        value={sprite.name}
+        checked={selected}
+        onChange={() => setSelectedSprite(sprite)}
+        className="sr-only peer" // Hidden visually but accessible to screen readers
+      />
+      <div className="p-1 rounded-md border-4 border-foreground/25 peer-checked:border-green-500">
+        <AnimatedSpritePreview
+          sprite={sprite}
+          width={width}
+          height={height}
+          isStatic={true}
+        />
+      </div>
+      <p
+        className={`text-sm text-center text-ellipsis peer-checked:text-green-500 ${
+          selected && "font-bold"
+        }`}
+      >
+        {sprite.displayName}
+      </p>
+    </label>
+  );
+}

--- a/frontend/src/app/game/components/huds/BackgroundOptions.tsx
+++ b/frontend/src/app/game/components/huds/BackgroundOptions.tsx
@@ -1,80 +1,82 @@
 "use client";
 
-import CameraFace from "@/components/icons/CameraFace";
 import {
   Dialog,
   DialogClose,
-  DialogTitle,
   DialogContent,
+  DialogTitle,
   DialogTrigger,
 } from "@/components/ui/Dialog";
 import {
-  Sprite,
-  SpriteName,
-  SPRITES,
-  SPRITES_MAP,
+  Background,
+  BackgroundName,
+  BACKGROUNDS,
+  BACKGROUNDS_MAP,
 } from "@/app/game/gameAssets";
 import { useEffect, useState } from "react";
 import GameButton from "@/app/game/components/GameButton";
+import Chess from "@/components/icons/Chess";
 import AnimatedSpritePreview from "../AnimatedSpritePreview";
 import SpritePreviewOption from "../SpritePreviewOption";
 
 export default function AvatarOptions({
-  avatar,
-  setAvatar,
+  background,
+  setBackground,
 }: {
-  avatar: SpriteName;
-  setAvatar: (s: SpriteName) => void;
+  background: BackgroundName;
+  setBackground: (b: BackgroundName) => void;
 }) {
-  const [selectedAvatar, setSelectedAvatar] = useState<Sprite>(
-    SPRITES_MAP.get(avatar)!
+  const [selectedBackground, setSelectedBackground] = useState<Background>(
+    BACKGROUNDS_MAP.get(background)!
   );
 
   useEffect(() => {
-    setSelectedAvatar(SPRITES_MAP.get(avatar)!);
-  }, [avatar]);
+    setSelectedBackground(BACKGROUNDS_MAP.get(background)!);
+  }, [background]);
 
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <GameButton tooltipText="Avatars">
-          <CameraFace width={32} height={32} />
+        <GameButton tooltipText="Backgrounds">
+          <Chess width={32} height={32} />
         </GameButton>
       </DialogTrigger>
       <DialogContent>
         <DialogTitle className="font-bold text-center text-xl">
-          Change Avatar
+          Change Backgrounds
         </DialogTitle>
         <div className="flex justify-center gap-4">
           {/* Avatar Preview - Shows animated version of selected avatar */}
           <div className="flex-1 flex justify-center items-center">
             <AnimatedSpritePreview
-              sprite={selectedAvatar}
-              width={256}
-              height={256}
+              sprite={selectedBackground}
+              width={320}
+              height={180}
             />
           </div>
           {/* Grid of selectable avatar options */}
           <div className="grid grid-cols-2 h-96 overflow-y-auto">
-            {SPRITES.map((sprite) => (
+            {BACKGROUNDS.map((background) => (
               <SpritePreviewOption
-                key={sprite.name}
-                name="avatar-options"
-                sprite={sprite}
-                width={128}
-                height={128}
-                selectedSprite={selectedAvatar}
-                setSelectedSprite={setSelectedAvatar}
+                key={background.name}
+                name="background-options"
+                sprite={background}
+                width={96}
+                height={54}
+                selectedSprite={selectedBackground}
+                setSelectedSprite={setSelectedBackground}
               />
             ))}
           </div>
         </div>
         <DialogClose
           className="bg-foreground text-background w-full p-2 rounded-md cursor-pointer duration-150 disabled:opacity-15 hover:bg-foreground/85 disabled:cursor-not-allowed"
-          disabled={avatar === selectedAvatar.name}
-          onClick={() => setAvatar(selectedAvatar.name as SpriteName)}
+          disabled={background === selectedBackground.name}
+          onClick={() =>
+            setBackground(selectedBackground.name as BackgroundName)
+          }
         >
-          Save Avatar
+          Save Background
         </DialogClose>
       </DialogContent>
     </Dialog>

--- a/frontend/src/app/game/gameAssets.ts
+++ b/frontend/src/app/game/gameAssets.ts
@@ -1,9 +1,4 @@
-type ExtractKeyValues<
-  T extends ReadonlyArray<unknown>,
-  Key extends string,
-> = Extract<T[number], { [key in Key]: unknown }>[Key];
-
-export type Background = {
+export type BaseSprite = {
   name: string;
   displayName: string;
   path: string;
@@ -13,6 +8,13 @@ export type Background = {
     idle: { frames: number[]; loop: boolean; speed: number };
   };
 };
+
+type ExtractKeyValues<
+  T extends ReadonlyArray<unknown>,
+  Key extends string,
+> = Extract<T[number], { [key in Key]: unknown }>[Key];
+
+export type Background = BaseSprite;
 
 export const BACKGROUNDS = defineBackgrounds([
   {
@@ -93,14 +95,8 @@ export const BACKGROUNDS_MAP = new Map<string, Background>(
   BACKGROUNDS.map((background) => [background.name, background])
 );
 
-export type Sprite = {
-  name: string;
-  displayName: string;
-  path: string;
-  sliceX: number;
-  sliceY: number;
+export type Sprite = BaseSprite & {
   anims: {
-    idle: { frames: number[]; loop: boolean; speed: number };
     left: { frames: number[]; loop: boolean; speed: number };
     right: { frames: number[]; loop: boolean; speed: number };
   };

--- a/frontend/src/app/game/page.tsx
+++ b/frontend/src/app/game/page.tsx
@@ -3,12 +3,14 @@
 import { useEffect, useRef, useState } from "react";
 import GameController from "./GameController";
 import AvatarOptions from "./components/huds/AvatarOptions";
-import { SpriteName } from "./gameAssets";
+import { BackgroundName, SpriteName } from "./gameAssets";
+import BackgroundOptions from "./components/huds/BackgroundOptions";
 
 export default function Game() {
   // States
   const [gameController] = useState<GameController>(() => new GameController());
   const [avatar, setAvatar] = useState<SpriteName>("default");
+  const [background, setBackground] = useState<BackgroundName>("mountain");
 
   // Refs
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -19,7 +21,7 @@ export default function Game() {
       const gameHeight = 1080;
 
       // Initialise the game with the canvas, player sprite, and background
-      gameController.initGame(canvasRef.current, avatar, "night_sky");
+      gameController.initGame(canvasRef.current, avatar, background);
 
       /**
        * Function to resize the canvas to fit the window height
@@ -63,6 +65,10 @@ export default function Game() {
   }, [canvasRef, gameController]);
 
   useEffect(() => {
+    gameController.changeBackground(background);
+  }, [gameController, background]);
+
+  useEffect(() => {
     gameController.changePlayer(avatar);
   }, [gameController, avatar]);
 
@@ -70,11 +76,15 @@ export default function Game() {
     <div className="overflow-hidden relative flex items-center justify-center">
       <nav className="absolute top-0 flex justify-between p-4">
         {/* TODO: Left section of Navbar */}
-        <div>
+        <div className="flex gap-2 items-center">
           <AvatarOptions avatar={avatar} setAvatar={setAvatar} />
+          <BackgroundOptions
+            background={background}
+            setBackground={setBackground}
+          />
         </div>
         {/* TODO: Right section of Navbar */}
-        <div></div>
+        <div className="flex gap-2 items-center"></div>
       </nav>
       <canvas ref={canvasRef} id="game" />
     </div>


### PR DESCRIPTION
# What did you do?
Implemented the background options menu UI, which allows users to interchange between different backgrounds. Currently, users can change to any background. In the future, some of these can only be unlocked through levelling up.

# Preview
https://github.com/user-attachments/assets/aa43b903-0a36-4151-8347-ded3d57f7d0e


# PR Train
|     | PR #       | Title    |
| --- | ---------- | -------- |
|   | [#4](https://github.com/devsoc-unsw/trainee-grass-25t1/pull/4) | Refactor initGame into a Game Controller Class |
|   | [#5](https://github.com/devsoc-unsw/trainee-grass-25t1/pull/5) | Implement responsiveness to the game canvas |
|   | [#6](https://github.com/devsoc-unsw/trainee-grass-25t1/pull/6) | Implement Avatar Options Menu UI to interchangeably change between different avatars |
| 👉  | [#7](https://github.com/devsoc-unsw/trainee-grass-25t1/pull/7) | Implement Background Options Menu UI to interchangeably change between different backgrounds |

# References
Whiteboard: [Link](https://www.canva.com/design/DAGjpogaVdU/ifsHsS6aC1xdY-h4pGawzg/edit)
